### PR TITLE
chore: ignore task_definition changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,4 +87,7 @@ resource "aws_ecs_service" "ecs-service" {
       assign_public_ip = each.value.network_configuration.assign_public_ip
     }
   }
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }


### PR DESCRIPTION
In order to avoid that terraform showing changes on revision we put this ignore_changes lifecycle.

This could impact the task_definitions but we haven't found a way to define dynamic lifecycle.