### PR TITLE
chore: add desired_count to ignore_changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,6 @@ resource "aws_ecs_service" "ecs-service" {
     }
   }
   lifecycle {
-    ignore_changes = [task_definition]
+    ignore_changes = [task_definition, desired_count]
   }
 }


### PR DESCRIPTION
We will introduce desired_count on the ignore_changes in order to avoid desired count changes on services on a production cluster